### PR TITLE
fix(toOrdinal): revert changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function formatBytes(bytes) {
 }
 
 function toOrdinal(n) {
-  return n+["st","nd","rd"][n%10-1]||"th";
+    const v = n % 100;
+    return n + (ordinalSuffixes[(v - 20) % 10] || ordinalSuffixes[v] || ordinalSuffixes[0]);
 }
 
 function generateKey(length) {


### PR DESCRIPTION
The patch for `toOrdinal` by casey (#2) caused a few bugs:
- inputting a number 4, 5, 6, etc. returns only `th`
- inputting 11 returns `11st` instead of `11th`
- inputting 12 returns `12nd` instead of `12th`
- inputting 13 returns `13rd` instead of `13th`

The changes were unnecessary. So i've decided it's better to revert the changes.